### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+python:
+    - 2.6
+    - 2.7
+before_install:
+    # Diag output
+    - echo "before_install"
+    - echo $VIRTUAL_ENV
+    # Update system packages
+    - sudo apt-get update -qq
+    # Update pip to get wheel support
+    - pip install --upgrade pip setuptools wheel
+install:
+    # Dependencies
+    - pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --use-wheel --use-mirrors -r requirements.txt
+    # Build the extension modules
+    - python setup.py build_ext --inplace
+    # Link into virtualenv
+    - python setup.py develop
+script:
+    # Exclude regression and remote tests since they currently cause a fork bomb
+    - nosetests -e "regression|remote" mdf/tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+Cython
+numpy
+pyzmq
+ipython
+Pyro4==4.14
+decorator
+pandas
+pyparsing
+argparse
+matplotlib
+xlwt

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import os
+
 from setuptools import setup, find_packages
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
@@ -13,6 +15,9 @@ MDF - Data Flow Programming Toolkit
 version = '2.1'
 cython_profile = False
 cdebug = False
+
+with open("requirements.txt", "rb") as f:
+    requirements = f.read().split(os.linesep)
 
 if __name__ == "__main__":
 
@@ -37,34 +42,22 @@ if __name__ == "__main__":
 
     setup(
         name='mdf',
-        version = version,
+        version=version,
         description='MDF - Data Flow Programming Toolkit',
         long_description=long_description,
         zip_safe=False,
 
         # The icons directory is not a python package so find_packages will not find it.
         packages=find_packages() + ["mdf.viewer.icons"],
-        package_data = {'mdf.viewer.icons' : ['*.ico']},
-        test_suite = 'nose.collector',
+        package_data={'mdf.viewer.icons': ['*.ico']},
+        test_suite='nose.collector',
         setup_requires=[],
         scripts=glob("bin/*.py"),
-        install_requires=[
-            'Pyro4',
-            'Cython',
-            'numpy',
-            'wxPython',
-            'decorator',
-            'pandas',
-            'pyparsing',
-            'argparse',
-            'matplotlib',
-            'Pyro4',
-            'xlwt',
-        ],
+        install_requires=requirements,
         extras_require={
-           'win32' : ['pywin32', 'pyzmq'],
-           'linux2' : []
+            'win32': ['pywin32'],
+            'linux2': []
         },
-        cmdclass = {"build_ext": build_ext},
-        ext_modules = ext_modules,
+        cmdclass={"build_ext": build_ext},
+        ext_modules=ext_modules,
     )


### PR DESCRIPTION
Completes #2
- Requirements pulled out into requirements.txt
- wxPython dropped since it is optional (except for the viewer) and a pain to built on travis
- Tests involving multiprocessing are excluded from the travis build due to an inadvertent fork bomb
